### PR TITLE
Update neovim/conjure configuration instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -877,7 +877,7 @@ This is inspired by [Mocha](https://mochajs.org)'s excellent documentation.
 
 1. A user runs Lazytest, either through leiningen or Clojure CLI.
 2. Lazytest parses the command line arguments to determine the relevant configuration.
-3. Lazytest finds test files. If the user provides `--dir`, then every file in the file trees of all given directories are checked. Otherwise, all files within the `test` directorie are checked.
+3. Lazytest finds test files. If the user provides `--dir`, then every file in the file trees of all given directories are checked. Otherwise, all files within the `test` directory are checked.
 4. Lazytest loads all test files. Using `tools.namespace`, the namespace of each `.clj` is extracted and `require`d, which creates the necessary vars.
 5. Lazytest gathers all test vars from the required namespaces. It checks each var in each namespace against the following list of questions.
     1. Is the var defined with `defdescribe`? Call the `defdescribe`-constructed function and use the result.

--- a/README.md
+++ b/README.md
@@ -824,6 +824,7 @@ runners["test-runners"].lazytest = {
   ["name-suffix"] = ""
 }
 vim.g["conjure#client#clojure#nrepl#test#runner"] = "lazytest"
+vim.g["conjure#client#clojure#nrepl#test#current_form_names"] = { "describe" }
 ```
 
 ### VSCode


### PR DESCRIPTION
The configuration instructions for conjure in neovim should include setting the `current_form_names` variable so that the `run test under cursor` binding works.

This line was included in @NoahTheDuke's  [comment in the conjure repo](https://github.com/Olical/conjure/issues/525#issuecomment-1694940473) but was missing from the READM instructions.

A small typo is also fixed.